### PR TITLE
feat: auto-import real Apple Health history on every app open

### DIFF
--- a/agile-self/Services/HealthKit/HealthKitService.swift
+++ b/agile-self/Services/HealthKit/HealthKitService.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import HealthKit
+import SwiftData
 import os
 
 /// Provides read-only access to HealthKit data for building daily HealthSnapshot models.
@@ -87,11 +88,12 @@ final class HealthKitService {
 
     // MARK: - Data Fetching
 
-    /// Fetches today's health data and builds a HealthSnapshot.
-    /// Returns a snapshot with nil values for any unavailable metrics.
-    func fetchTodaySnapshot() async throws -> HealthSnapshot {
+    /// Fetches a single day's health data and builds a HealthSnapshot.
+    /// Returns a snapshot with nil values for any unavailable metrics. No side effects — the
+    /// today-fetch / history-import wrappers handle `isAuthorized` and persistence.
+    func fetchSnapshot(for day: Date) async throws -> HealthSnapshot {
         let calendar = Calendar.current
-        let startOfDay = calendar.startOfDay(for: Date())
+        let startOfDay = calendar.startOfDay(for: day)
         guard let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) else {
             return HealthSnapshot(date: startOfDay)
         }
@@ -135,7 +137,7 @@ final class HealthKitService {
         let heartRateValue = try await restingHeartRate
         let distanceValue = try await runningDistance
 
-        let snapshot = HealthSnapshot(
+        return HealthSnapshot(
             date: startOfDay,
             sleepMinutes: sleep,
             steps: stepsValue.map { Int($0) },
@@ -144,11 +146,64 @@ final class HealthKitService {
             restingHeartRate: heartRateValue.map { Int($0) },
             runningDistanceMeters: distanceValue
         )
-        // HealthKit never reports read-authorization status, so infer access from whether
-        // any metric returned data. Denial / no data → isAuthorized stays false, UI degrades.
+    }
+
+    /// Fetches today's health data and builds a HealthSnapshot. Infers read-authorization from
+    /// whether any metric returned (HealthKit never reports it directly).
+    func fetchTodaySnapshot() async throws -> HealthSnapshot {
+        let snapshot = try await fetchSnapshot(for: Date())
         isAuthorized = snapshot.hasAnyMetric
-        AppLog.health.notice("fetch sleep=\(sleep != nil, privacy: .public) steps=\(stepsValue != nil, privacy: .public) cals=\(caloriesValue != nil, privacy: .public) exercise=\(exerciseValue != nil, privacy: .public) hr=\(heartRateValue != nil, privacy: .public) dist=\(distanceValue != nil, privacy: .public) anyMetric=\(snapshot.hasAnyMetric, privacy: .public) (sim/no-data → all false)")
+        AppLog.health.notice("fetch today anyMetric=\(snapshot.hasAnyMetric, privacy: .public) (sim/no-data → false)")
         return snapshot
+    }
+
+    // MARK: - Historical Import
+
+    /// Backfills the last `days` days of REAL HealthKit data into SwiftData, upserting each day
+    /// by start-of-day so any prior row (including demo-seeded ones) is replaced with real
+    /// metrics. Today is owned by the live `fetchTodaySnapshot` path and is left untouched.
+    /// Best-effort: a day that errors or has no readable metric is skipped. Returns the number
+    /// of days actually imported. Call on the main actor (uses the main `ModelContext`).
+    @discardableResult
+    func importRecentHistory(days: Int, context: ModelContext) async -> Int {
+        guard isAvailable, days > 0 else { return 0 }
+        if !hasRequestedAuthorization {
+            try? await requestAuthorization()
+        }
+
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        var imported = 0
+        for offset in 1...days {
+            guard let day = calendar.date(byAdding: .day, value: -offset, to: today) else { continue }
+            guard let snapshot = try? await fetchSnapshot(for: day), snapshot.hasAnyMetric else { continue }
+            upsertSnapshot(snapshot, context: context)
+            imported += 1
+        }
+
+        if imported > 0 {
+            isAuthorized = true
+            try? context.save()
+        }
+        AppLog.health.notice("imported \(imported, privacy: .public) historical health day(s) of \(days, privacy: .public)")
+        return imported
+    }
+
+    /// Upserts a snapshot by its start-of-day date. Updates ONLY the HealthKit-sourced metrics,
+    /// preserving any existing `screenTimeMinutes` (which is sourced from ScreenTime, not Health).
+    private func upsertSnapshot(_ snapshot: HealthSnapshot, context: ModelContext) {
+        let day = Calendar.current.startOfDay(for: snapshot.date)
+        let descriptor = FetchDescriptor<HealthSnapshot>(predicate: #Predicate { $0.date == day })
+        if let existing = try? context.fetch(descriptor).first {
+            existing.sleepMinutes = snapshot.sleepMinutes
+            existing.steps = snapshot.steps
+            existing.activeCalories = snapshot.activeCalories
+            existing.exerciseMinutes = snapshot.exerciseMinutes
+            existing.restingHeartRate = snapshot.restingHeartRate
+            existing.runningDistanceMeters = snapshot.runningDistanceMeters
+        } else {
+            context.insert(snapshot)
+        }
     }
 
     // MARK: - Private Helpers

--- a/agile-self/Views/Root/RootView.swift
+++ b/agile-self/Views/Root/RootView.swift
@@ -13,6 +13,8 @@ import SwiftData
 struct RootView: View {
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @Environment(\.modelContext) private var modelContext
+    @Environment(AppContainer.self) private var appContainer
+    @Environment(\.scenePhase) private var scenePhase
 
     /// One-shot deep-link flag: set true when the user finished onboarding via
     /// "Start First Check-in". MainTabView consumes it once on first appear to open
@@ -36,6 +38,38 @@ struct RootView: View {
         .task {
             ensureDefaultRecords()
             WidgetSnapshotWriter.update(context: modelContext)
+            await refreshHealthHistory()
+        }
+        .onChange(of: scenePhase) { _, phase in
+            // Re-import whenever the app returns to the foreground. The cold-launch open is
+            // already covered by `.task` above; this catches warm foregrounds (the throttle in
+            // `refreshHealthHistory` keeps rapid re-opens from re-querying HealthKit).
+            if phase == .active {
+                Task { await refreshHealthHistory() }
+            }
+        }
+    }
+
+    /// Imports the user's REAL Apple Health history (sleep, steps, activity, etc.) for the last
+    /// 30 days on every app open, upserting by date so new and late-syncing metrics refresh the
+    /// existing rows — past days get real data to correlate against their check-ins, not just
+    /// "today". Throttled to at most once per 30 minutes so opening the app repeatedly doesn't
+    /// re-query HealthKit needlessly; the throttle timestamp is recorded only after a SUCCESSFUL
+    /// import, so a launch before HealthKit is granted retries on the next open. Skipped before
+    /// onboarding and under UI tests. A manual full re-import lives in Settings → "Import Apple
+    /// Health".
+    private func refreshHealthHistory() async {
+        guard hasCompletedOnboarding else { return }
+        guard !ProcessInfo.processInfo.arguments.contains("UITEST") else { return }
+
+        let key = "lastHealthImportAt"
+        let now = Date().timeIntervalSince1970
+        let last = UserDefaults.standard.double(forKey: key)
+        guard now - last > 30 * 60 else { return }   // at most once / 30 min
+
+        let imported = await appContainer.healthKitService.importRecentHistory(days: 30, context: modelContext)
+        if imported > 0 {
+            UserDefaults.standard.set(now, forKey: key)
         }
     }
 

--- a/agile-self/Views/Settings/SettingsView.swift
+++ b/agile-self/Views/Settings/SettingsView.swift
@@ -39,6 +39,8 @@ struct SettingsView: View {
     @State private var exportFile: ExportedDataFile?
     @State private var showExportShare = false
     @State private var showDeleteConfirmation = false
+    @State private var isImportingHealth = false
+    @State private var healthImportMessage: String?
 
     // MARK: - Constants
 
@@ -485,6 +487,27 @@ struct SettingsView: View {
                     .overlay(Theme.Colors.divider)
                     .padding(.leading, Theme.Spacing.md + 24 + Theme.Spacing.md)
 
+                // Backfills real Apple Health history (sleep, steps, activity) for the last 30
+                // days so past check-ins have real metrics to correlate against — not just today.
+                Button {
+                    Task { await importAppleHealthHistory() }
+                } label: {
+                    dataRowLabel(
+                        icon: "heart.text.square.fill",
+                        title: "Import Apple Health",
+                        trailing: isImportingHealth ? "…" : nil,
+                        iconColor: Theme.Colors.heartRate
+                    )
+                }
+                .buttonStyle(.plain)
+                .disabled(isImportingHealth)
+                .accessibilityLabel("Import Apple Health history")
+                .accessibilityHint("Backfills your past sleep, steps, and activity for correlations")
+
+                Divider()
+                    .overlay(Theme.Colors.divider)
+                    .padding(.leading, Theme.Spacing.md + 24 + Theme.Spacing.md)
+
                 Button(role: .destructive) {
                     showDeleteConfirmation = true
                 } label: {
@@ -497,6 +520,28 @@ struct SettingsView: View {
             .background(Theme.Colors.backgroundSecondary)
             .clipShape(RoundedRectangle(cornerRadius: Theme.CornerRadius.large))
         }
+        .alert(
+            "Apple Health",
+            isPresented: Binding(
+                get: { healthImportMessage != nil },
+                set: { if !$0 { healthImportMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) { healthImportMessage = nil }
+        } message: {
+            Text(healthImportMessage ?? "")
+        }
+    }
+
+    /// Imports the last 30 days of real Apple Health data and reports how many days landed.
+    private func importAppleHealthHistory() async {
+        guard !isImportingHealth else { return }
+        isImportingHealth = true
+        let imported = await appContainer.healthKitService.importRecentHistory(days: 30, context: modelContext)
+        isImportingHealth = false
+        healthImportMessage = imported > 0
+            ? "Imported \(imported) day\(imported == 1 ? "" : "s") of Apple Health data."
+            : "No Apple Health data was available to import. Make sure Health access is allowed for Agile Self."
     }
 
     private func dataRowLabel(icon: String, title: String, trailing: String?, iconColor: Color) -> some View {


### PR DESCRIPTION
## What & why

Past check-ins had **no real health data to correlate against** — the app only ever persisted *today's* HealthKit snapshot, so historical mood↔sleep/steps analysis was impossible (in testing, the only past health present was demo-seed). This backfills real Apple Health history and keeps it fresh on every app open, which is the precondition for the app's core "mood ↔ health" value.

## Changes

- **`HealthKitService`**: `fetchSnapshot(for:)` generalizes the today-only fetch to any day (the underlying queries already took date ranges), and `importRecentHistory(days:context:)` backfills the last 30 days — upserting each day by **start-of-day** so prior rows (including any demo-seeded health) are replaced with real metrics. Today stays owned by the live fetch; best-effort, skips days with no readable metric.
- **Trigger (`RootView`)**: runs on **every app open** — cold launch (`.task`) and warm foreground (`scenePhase → .active`) — **throttled to ≤ once / 30 min** so rapid re-opens don't re-query HealthKit. The throttle timestamp is recorded **only after a successful import**, so a launch before Health is granted retries on the next open.
- **Settings → "Import Apple Health"**: manual full re-import with a result alert.

## Verification (on a real iPhone 16)

- Confirmed `lastHealthImportAt` is written on open (import ran **and** succeeded), and a relaunch 30 s later correctly **throttle-skipped** (timestamp didn't advance).
- Past-day metrics are now **real** (sleep 196–601 min, steps 1.1k–18.3k), replacing the seed formula — enabling real correlations (e.g. **Sleep ↔ Calm r = +0.48** across 15 days, where before only "today" was real).
- Build: simulator **and** device SUCCEEDED.

## Notes

- A vestigial `didImportHealthHistory.v1` UserDefaults key may linger from an interim build; it's harmless — the shipped code uses `lastHealthImportAt`.
- Per the service guideline (HealthKit is read-only), this never writes to HealthKit; it only reads and persists snapshots to SwiftData, consistent with the existing today-fetch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
