### PR TITLE
feat(watch): rebuild Apple Watch check-in as a simple, reliable tap flow

### DIFF
--- a/agile-self Watch App/ContentView.swift
+++ b/agile-self Watch App/ContentView.swift
@@ -2,7 +2,8 @@
 //  ContentView.swift
 //  agile-self Watch App
 //
-//  Home screen: score display, streak badge, check-in CTA.
+//  Minimal home: today's status, the streak, and one big "Check In" CTA. Once checked in,
+//  the CTA is replaced by a calm "Done" state showing today's composite score.
 //
 
 import SwiftUI
@@ -14,82 +15,129 @@ struct ContentView: View {
     var body: some View {
         NavigationStack {
             ScrollView {
-                VStack(spacing: 12) {
-                    // Header
+                VStack(spacing: 14) {
                     Text("Agile Self")
-                        .font(.headline)
-                        .foregroundStyle(
-                            WatchTheme.Colors.accentGradient
-                        )
+                        .font(.system(.headline, design: .rounded))
+                        .foregroundStyle(WatchTheme.Colors.accentGradient)
 
-                    // Score or placeholder
-                    if let score = connectivity.todayCompositeScore {
-                        VStack(spacing: 2) {
-                            Text(String(format: "%.1f", score))
-                                .font(.system(size: 44, weight: .bold, design: .rounded))
-                                .foregroundStyle(WatchTheme.Colors.textPrimary)
+                    statusSection
 
-                            Text("Today's Score")
-                                .font(.caption2)
-                                .foregroundStyle(WatchTheme.Colors.textSecondary)
-                        }
-                    } else {
-                        VStack(spacing: 4) {
-                            Image(systemName: "chart.bar.fill")
-                                .font(.title2)
-                                .foregroundStyle(WatchTheme.Colors.textTertiary)
-
-                            Text("No check-in yet")
-                                .font(.caption2)
-                                .foregroundStyle(WatchTheme.Colors.textSecondary)
-                        }
-                        .padding(.vertical, 8)
-                    }
-
-                    // Streak badge
                     if connectivity.currentStreak > 0 {
-                        HStack(spacing: 4) {
-                            Image(systemName: "flame.fill")
-                                .font(.caption2)
-                                .foregroundStyle(.orange)
-                            Text("\(connectivity.currentStreak) day streak")
-                                .font(.caption2)
-                                .foregroundStyle(WatchTheme.Colors.textSecondary)
-                        }
+                        streakBadge
                     }
 
-                    // Check-in button
                     if connectivity.didCheckInToday {
-                        Label("Done", systemImage: "checkmark.circle.fill")
-                            .font(.footnote)
-                            .foregroundStyle(WatchTheme.Colors.success)
+                        doneState
                     } else {
-                        Button {
-                            showCheckIn = true
-                        } label: {
-                            Text("Check In")
-                                .font(.footnote.bold())
-                                .foregroundStyle(.white)
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 8)
-                                .background(
-                                    WatchTheme.Colors.accentGradient,
-                                    in: Capsule()
-                                )
-                        }
-                        .buttonStyle(.plain)
+                        checkInButton
                     }
                 }
+                .frame(maxWidth: .infinity)
                 .padding(.horizontal, 8)
+                .padding(.top, 4)
             }
+            .scrollBounceBehavior(.basedOnSize)
             .background(WatchTheme.Colors.backgroundPrimary)
-            .sheet(isPresented: $showCheckIn) {
-                WatchCheckInView(connectivity: connectivity)
-            }
         }
+        .sheet(isPresented: $showCheckIn) {
+            WatchCheckInView(connectivity: connectivity)
+        }
+    }
+
+    // MARK: - Status
+
+    @ViewBuilder
+    private var statusSection: some View {
+        if connectivity.didCheckInToday, let score = connectivity.todayCompositeScore {
+            VStack(spacing: 2) {
+                // Word-first headline mapped from the 1–5 composite (matches iOS).
+                Text(watchCompositeWord(for: score))
+                    .font(.system(.footnote, design: .rounded).weight(.semibold))
+                    .foregroundStyle(WatchTheme.Colors.textSecondary)
+
+                // Bold typographic hero: a big rounded numeral in the accent gradient.
+                Text(String(format: "%.1f", score))
+                    .font(.system(size: 52, weight: .bold, design: .rounded))
+                    .foregroundStyle(WatchTheme.Colors.accentGradient)
+                    .contentTransition(.numericText())
+
+                Text("Today's score")
+                    .font(.caption2)
+                    .foregroundStyle(WatchTheme.Colors.textSecondary)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(String(format: "%@. Today's score %.1f out of 5.", watchCompositeWord(for: score), score))
+        } else {
+            VStack(spacing: 6) {
+                Image(systemName: "sparkles")
+                    .font(.title3)
+                    .foregroundStyle(WatchTheme.Colors.textTertiary)
+                Text("No check-in yet")
+                    .font(.caption)
+                    .foregroundStyle(WatchTheme.Colors.textSecondary)
+            }
+            .padding(.vertical, 6)
+        }
+    }
+
+    // MARK: - Streak
+
+    private var streakBadge: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "flame.fill")
+                .font(.caption2)
+                .foregroundStyle(WatchTheme.Dimension.energy)
+            Text("\(connectivity.currentStreak) day streak")
+                .font(.caption2)
+                .foregroundStyle(WatchTheme.Colors.textSecondary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(WatchTheme.Colors.backgroundTertiary, in: Capsule())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(connectivity.currentStreak) day streak")
+    }
+
+    // MARK: - Done State
+
+    private var doneState: some View {
+        Label("Checked in", systemImage: "checkmark.circle.fill")
+            .font(.footnote.weight(.semibold))
+            .foregroundStyle(WatchTheme.Colors.success)
+            .padding(.top, 2)
+            .accessibilityLabel("Checked in today")
+    }
+
+    // MARK: - CTA
+
+    private var checkInButton: some View {
+        Button {
+            showCheckIn = true
+        } label: {
+            Text("Check In")
+                .font(.system(.footnote, design: .rounded).bold())
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .background(WatchTheme.Colors.accentGradient, in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Start daily check-in")
     }
 }
 
-#Preview {
+// MARK: - Previews
+
+#Preview("Not checked in") {
     ContentView(connectivity: WatchConnectivityManager())
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Checked in") {
+    let manager = WatchConnectivityManager()
+    manager.didCheckInToday = true
+    manager.todayCompositeScore = 3.8
+    manager.currentStreak = 5
+    return ContentView(connectivity: manager)
+        .preferredColorScheme(.dark)
 }

--- a/agile-self Watch App/WatchCheckInView.swift
+++ b/agile-self Watch App/WatchCheckInView.swift
@@ -2,219 +2,394 @@
 //  WatchCheckInView.swift
 //  agile-self Watch App
 //
-//  4-step Digital Crown check-in flow for Watch.
+//  Tap-to-advance check-in flow: one full-screen card per dimension, a level (1..5) picked
+//  by TAPPING a face (haptic + auto-advance), then a summary card with composite + Save.
+//
+//  NO Digital Crown, NO .focusable() / .digitalCrownRotation — tappable buttons only. The
+//  crown-based flow did not respond on device; this replaces it.
 //
 
 import SwiftUI
+import WatchKit
+
+// MARK: - WatchCheckInView
 
 struct WatchCheckInView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var connectivity: WatchConnectivityManager
 
-    @State private var currentStep = 0
-    @State private var scores: [Int] = [3, 3, 3, 3]
-    @State private var showConfirmation = false
+    /// The current page: 0..3 are the four dimensions, 4 is the summary card.
+    @State private var page = 0
+    /// nil until the user picks a level for that dimension. Pre-filling would let an
+    /// untouched dimension silently count as a "3" — keep intent explicit.
+    @State private var scores: [Int?] = [nil, nil, nil, nil]
     @State private var showSuccess = false
+    /// Bumped on success-appear to fire the checkmark bounce exactly once (and only when
+    /// Reduce Motion is off). A value-change symbol effect needs a changing value to play.
+    @State private var bounceTrigger = 0
+    /// Cancellable timers so a fast user (or a dismiss) never fires a stale advance/dismiss.
+    @State private var advanceTask: Task<Void, Never>?
+    @State private var dismissTask: Task<Void, Never>?
 
     private let dimensions = WatchDimensionType.allCases
+    private var summaryPage: Int { dimensions.count }       // 4
+    private var totalPages: Int { dimensions.count + 1 }    // 5 (4 dims + summary)
 
     var body: some View {
-        Group {
+        ZStack {
+            WatchTheme.Colors.backgroundPrimary.ignoresSafeArea()
+
             if showSuccess {
                 successView
-            } else if showConfirmation {
-                confirmationView
+                    .transition(.opacity)
             } else {
-                dimensionPicker
-            }
-        }
-        .background(WatchTheme.Colors.backgroundPrimary)
-    }
-
-    // MARK: - Dimension Picker
-
-    private var dimensionPicker: some View {
-        let dimension = dimensions[currentStep]
-        let color = WatchTheme.Dimension.color(for: dimension)
-
-        return VStack(spacing: 4) {
-            // Progress dots
-            HStack(spacing: 6) {
-                ForEach(0..<4, id: \.self) { index in
-                    Circle()
-                        .fill(index <= currentStep ? color : WatchTheme.Colors.textTertiary)
-                        .frame(width: 6, height: 6)
-                }
-            }
-
-            Spacer()
-
-            // Icon + Label
-            Image(systemName: dimension.icon)
-                .font(.title3)
-                .foregroundStyle(color)
-
-            Text(dimension.label)
-                .font(.headline)
-                .foregroundStyle(WatchTheme.Colors.textPrimary)
-
-            // Score display
-            Text("\(scores[currentStep])")
-                .font(.system(size: 44, weight: .bold, design: .rounded))
-                .foregroundStyle(color)
-                .focusable()
-                .digitalCrownRotation(
-                    detent: $scores[currentStep],
-                    from: 1,
-                    through: 5,
-                    by: 1,
-                    sensitivity: .low,
-                    isContinuous: false,
-                    isHapticFeedbackEnabled: true
-                )
-
-            Spacer()
-
-            // Navigation
-            HStack {
-                if currentStep > 0 {
-                    Button {
-                        withAnimation { currentStep -= 1 }
-                    } label: {
-                        Image(systemName: "chevron.left")
+                TabView(selection: $page) {
+                    ForEach(Array(dimensions.enumerated()), id: \.element.id) { index, dimension in
+                        DimensionCard(
+                            dimension: dimension,
+                            selected: scores[index],
+                            onPick: { level in pick(level, at: index) }
+                        )
+                        .tag(index)
                     }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(WatchTheme.Colors.textSecondary)
-                }
 
-                Spacer()
-
-                Button {
-                    withAnimation {
-                        if currentStep < 3 {
-                            currentStep += 1
-                        } else {
-                            showConfirmation = true
-                        }
-                    }
-                } label: {
-                    Text(currentStep < 3 ? "Next" : "Review")
-                        .font(.footnote.bold())
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
-                        .background(color, in: Capsule())
-                }
-                .buttonStyle(.plain)
-            }
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-    }
-
-    // MARK: - Confirmation
-
-    private var confirmationView: some View {
-        ScrollView {
-            VStack(spacing: 8) {
-                Text(String(format: "%.1f", compositeScore))
-                    .font(.system(size: 36, weight: .bold, design: .rounded))
-                    .foregroundStyle(
-                        WatchTheme.Colors.accentGradient
+                    SummaryCard(
+                        dimensions: dimensions,
+                        scores: scores,
+                        composite: compositeScore,
+                        canSave: allScored,
+                        onSave: save
                     )
-
-                Text("Composite")
-                    .font(.caption2)
-                    .foregroundStyle(WatchTheme.Colors.textSecondary)
-
-                ForEach(Array(dimensions.enumerated()), id: \.element.id) { index, dim in
-                    HStack {
-                        Image(systemName: dim.icon)
-                            .font(.caption2)
-                            .foregroundStyle(WatchTheme.Dimension.color(for: dim))
-                        Text(dim.label)
-                            .font(.caption2)
-                            .foregroundStyle(WatchTheme.Colors.textSecondary)
-                        Spacer()
-                        Text("\(scores[index])")
-                            .font(.caption.bold())
-                            .foregroundStyle(WatchTheme.Colors.textPrimary)
-                    }
+                    .tag(summaryPage)
                 }
-
-                HStack(spacing: 12) {
-                    Button {
-                        withAnimation { showConfirmation = false }
-                    } label: {
-                        Image(systemName: "chevron.left")
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(WatchTheme.Colors.textSecondary)
-
-                    Button {
-                        save()
-                    } label: {
-                        Text("Save")
-                            .font(.footnote.bold())
-                            .foregroundStyle(.white)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 6)
-                            .background(
-                                WatchTheme.Colors.accentGradient,
-                                in: Capsule()
-                            )
-                    }
-                    .buttonStyle(.plain)
-                }
-                .padding(.top, 4)
+                .tabViewStyle(.verticalPage)
+                .overlay(alignment: .top) { progressDots }
+                .transition(.opacity)
             }
-            .padding(.horizontal, 8)
         }
+        .onDisappear {
+            advanceTask?.cancel()
+            dismissTask?.cancel()
+        }
+    }
+
+    // MARK: - Progress dots
+
+    /// A persistent 5-step indicator pinned to the top across all pages (4 dimensions +
+    /// summary), tinted by the current dimension's color (accent on the summary).
+    private var progressDots: some View {
+        HStack(spacing: 6) {
+            ForEach(0 ..< totalPages, id: \.self) { dot in
+                Circle()
+                    .fill(dot <= page ? filledDotColor : WatchTheme.Colors.textTertiary)
+                    .frame(width: 6, height: 6)
+            }
+        }
+        .padding(.top, 4)
+        .accessibilityHidden(true)
+    }
+
+    private var filledDotColor: Color {
+        page < dimensions.count
+            ? WatchTheme.Dimension.color(for: dimensions[page])
+            : WatchTheme.Colors.accentStart
     }
 
     // MARK: - Success
 
     private var successView: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 8) {
             Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 48))
+                .font(.system(size: 42))
                 .foregroundStyle(WatchTheme.Colors.success)
+                .symbolEffect(.bounce, value: bounceTrigger)
 
-            Text("Saved!")
-                .font(.headline)
+            Text(watchCompositeWord(for: compositeScore))
+                .font(.system(.headline, design: .rounded).weight(.semibold))
                 .foregroundStyle(WatchTheme.Colors.textPrimary)
 
             Text(String(format: "%.1f", compositeScore))
-                .font(.title3.bold())
-                .foregroundStyle(
-                    WatchTheme.Colors.accentGradient
-                )
+                .font(.system(size: 30, weight: .bold, design: .rounded))
+                .foregroundStyle(WatchTheme.Colors.accentGradient)
         }
+        .padding()
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(String(format: "%@. Composite score %.1f out of 5. Saved.", watchCompositeWord(for: compositeScore), compositeScore))
         .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            WKInterfaceDevice.current().play(.success)
+            if !reduceMotion { bounceTrigger += 1 }   // play the checkmark bounce once
+            // Brief linger so the confirmation registers, then dismiss back to Home.
+            dismissTask?.cancel()
+            dismissTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(1.3))
+                guard !Task.isCancelled else { return }
                 dismiss()
             }
         }
     }
 
-    // MARK: - Helpers
+    // MARK: - Actions
 
-    private var compositeScore: Double {
-        // scores[2] is the Calm axis (high = calm/good).
-        computeCompositeScore(energy: scores[0], focus: scores[1], calm: scores[2], growth: scores[3])
+    private func pick(_ level: Int, at index: Int) {
+        // Only auto-advance the FIRST time a dimension is scored. If the user swiped back to
+        // correct an already-scored card, update the value + haptic but stay put.
+        let isFirstSelection = scores[index] == nil
+        scores[index] = level
+        WKInterfaceDevice.current().play(.click)
+
+        guard isFirstSelection else { return }
+
+        let next = index + 1
+        advanceTask?.cancel()
+        if reduceMotion {
+            page = next
+        } else {
+            // Tiny delay lets the selection "pop" register before the page slides.
+            advanceTask = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(200))
+                guard !Task.isCancelled else { return }
+                withAnimation(.easeInOut(duration: 0.28)) { page = next }
+            }
+        }
     }
 
     private func save() {
-        connectivity.sendCheckIn(
-            energy: scores[0],
-            focus: scores[1],
-            calm: scores[2],
-            growth: scores[3]
-        )
-        withAnimation { showSuccess = true }
+        // scores are all non-nil here (Save is gated on `allScored`); default to 3 defensively.
+        let e = scores[0] ?? 3
+        let f = scores[1] ?? 3
+        let c = scores[2] ?? 3
+        let g = scores[3] ?? 3
+        // Optimistically reflect the check-in locally so Home + the success screen agree even
+        // if the phone never sends a reply (reachable-but-no-reply). handleReply later reconciles
+        // with the phone's authoritative composite + streak. Idempotent; only touches local state.
+        connectivity.applyLocalState(energy: e, focus: f, calm: c, growth: g)
+        connectivity.sendCheckIn(energy: e, focus: f, calm: c, growth: g)
+        withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.25)) { showSuccess = true }
+    }
+
+    // MARK: - Helpers
+
+    private var allScored: Bool { scores.allSatisfy { $0 != nil } }
+
+    private var compositeScore: Double {
+        let total = scores.reduce(0) { $0 + ($1 ?? 3) }
+        return Double(total) / Double(dimensions.count)
     }
 }
 
+// MARK: - DimensionCard
+
+/// One full-screen card: dimension header, a big tinted hero (face + large numeral) echoing
+/// the current pick, and a row of five tappable faces. Tapping a face selects it (handled by
+/// the parent: haptic + auto-advance). Scrollable + vertically centered so it stays balanced at
+/// the default text size yet never clips at large Dynamic Type / accessibility sizes.
+private struct DimensionCard: View {
+    let dimension: WatchDimensionType
+    let selected: Int?
+    let onPick: (Int) -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var color: Color { WatchTheme.Dimension.color(for: dimension) }
+
+    var body: some View {
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(spacing: 10) {
+                    // Header: icon + bold typographic label.
+                    HStack(spacing: 6) {
+                        Image(systemName: dimension.icon)
+                            .font(.body)
+                            .foregroundStyle(color)
+                        Text(dimension.label.uppercased())
+                            .font(.system(.headline, design: .rounded).weight(.bold))
+                            .tracking(1.5)
+                            .foregroundStyle(WatchTheme.Colors.textPrimary)
+                    }
+
+                    // Hero: the selected level reads as a LARGE numeral beside its face. Before
+                    // a pick, a neutral face + "–" hints at the scale.
+                    HStack(spacing: 8) {
+                        WatchFaceGlyph(level: selected ?? 3, lineWidth: 3)
+                            .foregroundStyle(selected == nil ? WatchTheme.Colors.textSecondary : color)
+                            .frame(width: 46, height: 46)
+
+                        Text(selected.map(String.init) ?? "–")
+                            .font(.system(size: 44, weight: .bold, design: .rounded))
+                            .foregroundStyle(selected == nil ? WatchTheme.Colors.textTertiary : color)
+                            .contentTransition(.numericText())
+                            .frame(minWidth: 32)
+                    }
+                    .scaleEffect(selected == nil ? 1.0 : 1.06)
+                    .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.6), value: selected)
+                    .accessibilityHidden(true)
+
+                    // The five tappable faces — each claims an equal share of the row so they
+                    // never clip on the smallest (40mm) watch and breathe on the largest.
+                    HStack(spacing: 4) {
+                        ForEach(1 ... 5, id: \.self) { level in
+                            FaceButton(
+                                level: level,
+                                isSelected: selected == level,
+                                color: color,
+                                dimensionLabel: dimension.label,
+                                action: { onPick(level) }
+                            )
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+
+                    // Scale legend.
+                    HStack {
+                        Text("Low")
+                        Spacer()
+                        Text("High")
+                    }
+                    .font(.system(size: 11))
+                    .foregroundStyle(WatchTheme.Colors.textTertiary)
+                    .padding(.horizontal, 4)
+                }
+                .padding(.horizontal, 6)
+                .padding(.top, 18)   // headroom so content clears the overlaid progress dots
+                .padding(.bottom, 6)
+                .frame(maxWidth: .infinity, minHeight: proxy.size.height)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+        }
+    }
+}
+
+// MARK: - FaceButton
+
+/// A single tappable 1..5 face. Pops (scale + full opacity) when selected; dims when not.
+/// Expands to an equal share of the row (`maxWidth: .infinity`) so five fit any watch size.
+private struct FaceButton: View {
+    let level: Int
+    let isSelected: Bool
+    let color: Color
+    let dimensionLabel: String
+    let action: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        Button(action: action) {
+            WatchFaceGlyph(level: level)
+                .foregroundStyle(isSelected ? color : WatchTheme.Colors.textSecondary)
+                .frame(width: 22, height: 22)
+                .padding(3)
+                .background {
+                    Circle()
+                        .fill(color.opacity(isSelected ? 0.18 : 0))
+                        .overlay(
+                            Circle().stroke(color, lineWidth: isSelected ? 1.5 : 0)
+                        )
+                }
+                .scaleEffect(isSelected ? 1.12 : 1.0)
+                .opacity(isSelected ? 1.0 : 0.75)
+                .frame(maxWidth: .infinity)
+                .animation(reduceMotion ? nil : .spring(response: 0.28, dampingFraction: 0.6), value: isSelected)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(dimensionLabel) level \(level) of 5")
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    }
+}
+
+// MARK: - SummaryCard
+
+/// Final card: a word headline + composite score, the four dimension faces in a tinted row,
+/// and Save. Until every dimension is scored, the composite and any unscored face render as a
+/// neutral "–" — never a fabricated value the user didn't enter.
+private struct SummaryCard: View {
+    let dimensions: [WatchDimensionType]
+    let scores: [Int?]
+    let composite: Double
+    let canSave: Bool
+    let onSave: () -> Void
+
+    var body: some View {
+        // Centered + sized to fit a single screen so the summary never scrolls at the normal
+        // text size. The ScrollView is a safety net for very large Dynamic Type only — bounce
+        // is disabled while the content fits, so it reads as a static screen.
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(spacing: 5) {
+                    // Word-first headline mapped from the 1–5 composite (matches iOS).
+                    Text(canSave ? watchCompositeWord(for: composite) : "Your day")
+                        .font(.system(.caption2, design: .rounded).weight(.bold))
+                        .tracking(1.6)
+                        .textCase(.uppercase)
+                        .foregroundStyle(WatchTheme.Colors.textTertiary)
+
+                    // Composite numeral — only once every dimension is scored; otherwise a
+                    // neutral placeholder so we never show a number the user didn't produce.
+                    Text(canSave ? String(format: "%.1f", composite) : "–")
+                        .font(.system(size: 34, weight: .bold, design: .rounded))
+                        .foregroundStyle(canSave
+                            ? AnyShapeStyle(WatchTheme.Colors.accentGradient)
+                            : AnyShapeStyle(WatchTheme.Colors.textTertiary))
+                        .contentTransition(.numericText())
+
+                    // Four faces in a row, tinted by dimension color. Unscored = neutral "–".
+                    HStack(spacing: 4) {
+                        ForEach(Array(dimensions.enumerated()), id: \.element.id) { index, dim in
+                            let value = scores[index]
+                            VStack(spacing: 2) {
+                                WatchFaceGlyph(level: value ?? 3)
+                                    .foregroundStyle(value == nil ? WatchTheme.Colors.textTertiary : WatchTheme.Dimension.color(for: dim))
+                                    .frame(width: 22, height: 22)
+                                    .opacity(value == nil ? 0.5 : 1)
+                                Text(value.map(String.init) ?? "–")
+                                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                                    .foregroundStyle(value == nil ? WatchTheme.Colors.textTertiary : WatchTheme.Colors.textPrimary)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .accessibilityElement(children: .ignore)
+                            .accessibilityLabel(value == nil ? "\(dim.label) not scored" : "\(dim.label) \(value!) of 5")
+                        }
+                    }
+                    .padding(.top, 2)
+
+                    Button(action: onSave) {
+                        Text("Save")
+                            .font(.footnote.bold())
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 7)
+                            .background(
+                                WatchTheme.Colors.accentGradient,
+                                in: Capsule()
+                            )
+                            .opacity(canSave ? 1.0 : 0.4)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.top, 2)
+                    .disabled(!canSave)
+                    .accessibilityHint(canSave ? "Saves today's check-in" : "Score every dimension first")
+
+                    if !canSave {
+                        Text("Score every dimension to save")
+                            .font(.system(size: 11))
+                            .foregroundStyle(WatchTheme.Colors.textTertiary)
+                            .multilineTextAlignment(.center)
+                    }
+                }
+                .padding(.horizontal, 6)
+                .padding(.top, 16)   // headroom so content clears the overlaid progress dots
+                .padding(.bottom, 6)
+                .frame(maxWidth: .infinity, minHeight: proxy.size.height)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+        }
+    }
+}
+
+// MARK: - Preview
+
 #Preview {
     WatchCheckInView(connectivity: WatchConnectivityManager())
+        .preferredColorScheme(.dark)
 }

--- a/agile-self Watch App/WatchFaceGlyph.swift
+++ b/agile-self Watch App/WatchFaceGlyph.swift
@@ -1,0 +1,89 @@
+//
+//  WatchFaceGlyph.swift
+//  agile-self Watch App
+//
+//  Monochrome line-art face, ported from the iOS FaceGlyph so the watch matches the phone.
+//  The face is the hero of every check-in card: eyes (two dots) + a mouth whose curvature
+//  expresses the 1..5 level (1 = sad, 5 = happy). Pure SwiftUI — no UIKit.
+//
+
+import SwiftUI
+
+// MARK: - WatchFaceGlyph
+
+/// A 1..5 mood face rendered as line art. Inherits its stroke/fill color from the
+/// surrounding `.foregroundStyle(...)`, so callers tint it with a dimension color.
+struct WatchFaceGlyph: View {
+    /// 1 (sad) .. 5 (happy). Clamped internally.
+    let level: Int
+    var lineWidth: CGFloat = 2.2
+
+    var body: some View {
+        GeometryReader { geo in
+            let s = min(geo.size.width, geo.size.height)
+            let lvl = CGFloat(min(max(level, 1), 5))
+            let cx = geo.size.width / 2
+            let cy = geo.size.height / 2
+            let eyeY = cy - s * 0.10
+            let eyeDX = s * 0.18
+            let eyeR = max(1.0, s * 0.05)
+            let mouthY = cy + s * 0.16
+            let mouthHalf = s * 0.20
+            // Negative bend (sad) for low levels, positive (happy) for high levels.
+            let bend = (lvl - 3) * 0.10 * s
+
+            ZStack {
+                Circle()
+                    .frame(width: eyeR * 2, height: eyeR * 2)
+                    .position(x: cx - eyeDX, y: eyeY)
+                Circle()
+                    .frame(width: eyeR * 2, height: eyeR * 2)
+                    .position(x: cx + eyeDX, y: eyeY)
+                Path { p in
+                    p.move(to: CGPoint(x: cx - mouthHalf, y: mouthY))
+                    p.addQuadCurve(
+                        to: CGPoint(x: cx + mouthHalf, y: mouthY),
+                        control: CGPoint(x: cx, y: mouthY + bend * 2)
+                    )
+                }
+                .stroke(style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+            }
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Composite word headline
+
+/// Maps a 1.0–5.0 composite score to a short, encouraging word headline. Mirrors the iOS
+/// `CheckInConfirmationView` bands so the watch and phone speak the same language.
+func watchCompositeWord(for composite: Double) -> String {
+    switch composite {
+    case 4.5...: return "Great day"
+    case 3.5...: return "Good day"
+    case 2.5...: return "Steady day"
+    case 1.5...: return "Tough day"
+    default: return "Hard day"
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ZStack {
+        WatchTheme.Colors.backgroundPrimary.ignoresSafeArea()
+        VStack(spacing: 14) {
+            HStack(spacing: 6) {
+                ForEach(1...5, id: \.self) { level in
+                    WatchFaceGlyph(level: level)
+                        .foregroundStyle(WatchTheme.Dimension.energy)
+                        .frame(width: 28, height: 28)
+                }
+            }
+            Text(watchCompositeWord(for: 3.8))
+                .font(.system(.headline, design: .rounded))
+                .foregroundStyle(WatchTheme.Colors.textPrimary)
+        }
+    }
+    .preferredColorScheme(.dark)
+}

--- a/agile-self Watch App/agile_selfApp.swift
+++ b/agile-self Watch App/agile_selfApp.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 @main
 struct agile_self_Watch_AppApp: App {
-    @State private var connectivity = WatchConnectivityManager()
+    @State private var connectivity: WatchConnectivityManager
 
     init() {
         let manager = WatchConnectivityManager()
-        _connectivity = State(initialValue: manager)
         manager.activate()
+        _connectivity = State(initialValue: manager)
     }
 
     var body: some Scene {


### PR DESCRIPTION
## Why
The Apple Watch check-in didn't work in practice: the 4-step **Digital Crown** picker used `.digitalCrownRotation` with no focus management, so the crown often didn't respond on device — and it was clunky (4 crown steps + taps + review). This rebuilds it as a simple, beautiful, reliable **tap-based** check-in.

## What changed (watch UI only)
- **`WatchCheckInView`** — rewritten: `TabView(.verticalPage)`, one dimension per card; tap a face (1–5) → `.click` haptic → **auto-advance**. The summary card (composite + four dimension-tinted faces) **fits one screen with no scrolling**; **Save is gated** until every dimension is scored. Success = `.success` haptic + checkmark bounce, then auto-dismiss.
- **`ContentView`** — minimal home: today's status / streak / big **Check In** CTA ("Checked in" state once logged).
- **`WatchFaceGlyph.swift`** (new) — port of the iOS `FaceGlyph` + a shared `watchCompositeWord()` so the watch and phone speak the same language ("Good day", etc.).
- **`agile_selfApp`** — dedup a double `WatchConnectivityManager` init.

No Digital Crown anywhere for scoring (tap-only). Reduce Motion respected; full VoiceOver labels.

## Not touched / safe
`WatchConnectivityManager` (incl. `computeCompositeScore`) and `WatchDimensionType` are **unchanged** → the existing Watch unit tests stay green. **No iOS files changed.** Independent of the open HealthKit PR (#36).

## Verification
- `xcodebuild` Watch App build **SUCCEEDED** (generic watchOS, off `main`; also SE 3 40mm + Series 11 42mm sims).
- `** TEST SUCCEEDED **` — Watch unit tests.
- Screenshots on the **40mm** (tightest layout): home, dimension card (all five faces fit, no clip), summary (fits one screen, no scroll).
- Built via a design panel + adversarial review workflow; **8 findings fixed** (incl. a 40mm face-row clipping bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)